### PR TITLE
Implement sync() methods

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 lint:
-	eslint *.js
+	node_modules/.bin/eslint *.js
 
 test:
 	$(MAKE) lint && node --trace-deprecation --throw-deprecation test.js

--- a/android.js
+++ b/android.js
@@ -28,7 +28,7 @@ const parse = stdout => {
   return result;
 };
 
-const get = family => {
+const promise = family => {
   return execa.stdout("ip", args[family]).then(stdout => {
     return parse(stdout);
   });
@@ -39,8 +39,8 @@ const sync = family => {
   return parse(result.stdout);
 };
 
-module.exports.v4 = () => get("v4");
-module.exports.v6 = () => get("v6");
+module.exports.v4 = () => promise("v4");
+module.exports.v6 = () => promise("v6");
 
 module.exports.v4.sync = () => sync("v4");
 module.exports.v6.sync = () => sync("v6");

--- a/android.js
+++ b/android.js
@@ -8,27 +8,39 @@ const args = {
   v6: ["-6", "r"],
 };
 
+const parse = stdout => {
+  let result;
+
+  (stdout || "").trim().split("\n").some(line => {
+    const results = /default via (.+?) dev (.+?)( |$)/.exec(line) || [];
+    const gateway = results[1];
+    const iface = results[2];
+    if (gateway && net.isIP(gateway)) {
+      result = {gateway: gateway, interface: (iface ? iface : null)};
+      return true;
+    }
+  });
+
+  if (!result) {
+    throw new Error("Unable to determine default gateway");
+  }
+
+  return result;
+};
+
 const get = family => {
   return execa.stdout("ip", args[family]).then(stdout => {
-    let result;
-
-    (stdout || "").trim().split("\n").some(line => {
-      const results = /default via (.+?) dev (.+?)( |$)/.exec(line) || [];
-      const gateway = results[1];
-      const iface = results[2];
-      if (gateway && net.isIP(gateway)) {
-        result = {gateway: gateway, interface: (iface ? iface : null)};
-        return true;
-      }
-    });
-
-    if (!result) {
-      throw new Error("Unable to determine default gateway");
-    }
-
-    return result;
+    return parse(stdout);
   });
+};
+
+const sync = family => {
+  const result = execa.sync("ip", args[family]);
+  return parse(result.stdout);
 };
 
 module.exports.v4 = () => get("v4");
 module.exports.v6 = () => get("v6");
+
+module.exports.v4.sync = () => sync("v4");
+module.exports.v6.sync = () => sync("v6");

--- a/darwin.js
+++ b/darwin.js
@@ -30,7 +30,7 @@ const parse = (stdout, family) => {
   return result;
 };
 
-const get = family => {
+const promise = family => {
   return execa.stdout("netstat", args[family]).then(stdout => {
     return parse(stdout, family);
   });
@@ -41,8 +41,8 @@ const sync = family => {
   return parse(result.stdout, family);
 };
 
-module.exports.v4 = () => get("v4");
-module.exports.v6 = () => get("v6");
+module.exports.v4 = () => promise("v4");
+module.exports.v6 = () => promise("v6");
 
 module.exports.v4.sync = () => sync("v4");
 module.exports.v6.sync = () => sync("v6");

--- a/darwin.js
+++ b/darwin.js
@@ -9,28 +9,40 @@ const args = {
   v6: ["-rn", "-f", "inet6"],
 };
 
+const parse = (stdout, family) => {
+  let result;
+
+  (stdout || "").trim().split("\n").some(line => {
+    const results = line.split(/ +/) || [];
+    const target = results[0];
+    const gateway = results[1];
+    const iface = results[family === "v4" ? 5 : 3];
+    if (dests.indexOf(target) !== -1 && gateway && net.isIP(gateway)) {
+      result = {gateway: gateway, interface: (iface ? iface : null)};
+      return true;
+    }
+  });
+
+  if (!result) {
+    throw new Error("Unable to determine default gateway");
+  }
+
+  return result;
+};
+
 const get = family => {
   return execa.stdout("netstat", args[family]).then(stdout => {
-    let result;
-
-    (stdout || "").trim().split("\n").some(line => {
-      const results = line.split(/ +/) || [];
-      const target = results[0];
-      const gateway = results[1];
-      const iface = results[family === "v4" ? 5 : 3];
-      if (dests.indexOf(target) !== -1 && gateway && net.isIP(gateway)) {
-        result = {gateway: gateway, interface: (iface ? iface : null)};
-        return true;
-      }
-    });
-
-    if (!result) {
-      throw new Error("Unable to determine default gateway");
-    }
-
-    return result;
+    return parse(stdout, family);
   });
+};
+
+const sync = family => {
+  const result = execa.sync("netstat", args[family]);
+  return parse(result.stdout, family);
 };
 
 module.exports.v4 = () => get("v4");
 module.exports.v6 = () => get("v6");
+
+module.exports.v4.sync = () => sync("v4");
+module.exports.v6.sync = () => sync("v6");

--- a/freebsd.js
+++ b/freebsd.js
@@ -30,7 +30,7 @@ const parse = stdout => {
   return result;
 };
 
-const get = family => {
+const promise = family => {
   return execa.stdout("netstat", args[family]).then(stdout => {
     return parse(stdout);
   });
@@ -41,8 +41,8 @@ const sync = family => {
   return parse(result.stdout);
 };
 
-module.exports.v4 = () => get("v4");
-module.exports.v6 = () => get("v6");
+module.exports.v4 = () => promise("v4");
+module.exports.v6 = () => promise("v6");
 
 module.exports.v4.sync = () => sync("v4");
 module.exports.v6.sync = () => sync("v6");

--- a/freebsd.js
+++ b/freebsd.js
@@ -9,28 +9,40 @@ const args = {
   v6: ["-rn", "-f", "inet6"],
 };
 
+const parse = stdout => {
+  let result;
+
+  (stdout || "").trim().split("\n").some(line => {
+    const results = line.split(/ +/) || [];
+    const target = results[0];
+    const gateway = results[1];
+    const iface = results[3];
+    if (dests.indexOf(target) !== -1 && gateway && net.isIP(gateway)) {
+      result = {gateway: gateway, interface: (iface ? iface : null)};
+      return true;
+    }
+  });
+
+  if (!result) {
+    throw new Error("Unable to determine default gateway");
+  }
+
+  return result;
+};
+
 const get = family => {
   return execa.stdout("netstat", args[family]).then(stdout => {
-    let result;
-
-    (stdout || "").trim().split("\n").some(line => {
-      const results = line.split(/ +/) || [];
-      const target = results[0];
-      const gateway = results[1];
-      const iface = results[3];
-      if (dests.indexOf(target) !== -1 && gateway && net.isIP(gateway)) {
-        result = {gateway: gateway, interface: (iface ? iface : null)};
-        return true;
-      }
-    });
-
-    if (!result) {
-      throw new Error("Unable to determine default gateway");
-    }
-
-    return result;
+    return parse(stdout);
   });
+};
+
+const sync = family => {
+  const result = execa.sync("netstat", args[family]);
+  return parse(result.stdout);
 };
 
 module.exports.v4 = () => get("v4");
 module.exports.v6 = () => get("v6");
+
+module.exports.v4.sync = () => sync("v4");
+module.exports.v6.sync = () => sync("v6");

--- a/index.js
+++ b/index.js
@@ -11,9 +11,16 @@ if ([
   "sunos",
   "win32"
 ].indexOf(platform) !== -1) {
-  module.exports.v4 = () => require(`./${platform}`).v4();
-  module.exports.v6 = () => require(`./${platform}`).v6();
+  const fams = require(`./${platform}`);
+
+  module.exports.v4 = () => fams.v4();
+  module.exports.v6 = () => fams.v6();
+  module.exports.v4.sync = () => fams.v4.sync();
+  module.exports.v6.sync = () => fams.v6.sync();
 } else {
-  module.exports.v4 = () => { throw new Error(`Unsupported Platform: ${platform}`); };
-  module.exports.v6 = () => { throw new Error(`Unsupported Platform: ${platform}`); };
+  const noop = () => { throw new Error(`Unsupported Platform: ${platform}`); };
+  module.exports.v4 = noop;
+  module.exports.v6 = noop;
+  module.exports.v4.sync = noop;
+  module.exports.v6.sync = noop;
 }

--- a/index.js
+++ b/index.js
@@ -11,12 +11,12 @@ if ([
   "sunos",
   "win32"
 ].indexOf(platform) !== -1) {
-  const fams = require(`./${platform}`);
+  const families = require(`./${platform}`);
 
-  module.exports.v4 = () => fams.v4();
-  module.exports.v6 = () => fams.v6();
-  module.exports.v4.sync = () => fams.v4.sync();
-  module.exports.v6.sync = () => fams.v6.sync();
+  module.exports.v4 = () => families.v4();
+  module.exports.v6 = () => families.v6();
+  module.exports.v4.sync = () => families.v4.sync();
+  module.exports.v6.sync = () => families.v6.sync();
 } else {
   const noop = () => { throw new Error(`Unsupported Platform: ${platform}`); };
   module.exports.v4 = noop;

--- a/linux.js
+++ b/linux.js
@@ -9,38 +9,50 @@ const args = {
   v6: ["-6", "r"],
 };
 
+const parse = (stdout, family) => {
+  let result;
+
+  (stdout || "").trim().split("\n").some(line => {
+    const results = /default( via .+?)?( dev .+?)( |$)/.exec(line) || [];
+    const gateway = (results[1] || "").substring(5);
+    const iface = (results[2] || "").substring(5);
+    if (gateway && net.isIP(gateway)) { // default via 1.2.3.4 dev en0
+      result = {gateway: gateway, interface: (iface ? iface : null)};
+      return true;
+    } else if (iface && !gateway) { // default via dev en0
+      const interfaces = os.networkInterfaces();
+      const addresses = interfaces[iface];
+      if (!addresses || !addresses.length) return;
+
+      addresses.some(function(addr) {
+        if (addr.family.substring(2) === family && net.isIP(addr.address)) {
+          result = {gateway: addr.address, interface: (iface ? iface : null)};
+          return true;
+        }
+      });
+    }
+  });
+
+  if (!result) {
+    throw new Error("Unable to determine default gateway");
+  }
+
+  return result;
+};
+
 const get = family => {
   return execa.stdout("ip", args[family]).then(stdout => {
-    let result;
-
-    (stdout || "").trim().split("\n").some(line => {
-      const results = /default( via .+?)?( dev .+?)( |$)/.exec(line) || [];
-      const gateway = (results[1] || "").substring(5);
-      const iface = (results[2] || "").substring(5);
-      if (gateway && net.isIP(gateway)) { // default via 1.2.3.4 dev en0
-        result = {gateway: gateway, interface: (iface ? iface : null)};
-        return true;
-      } else if (iface && !gateway) { // default via dev en0
-        const interfaces = os.networkInterfaces();
-        const addresses = interfaces[iface];
-        if (!addresses || !addresses.length) return;
-
-        addresses.some(function(addr) {
-          if (addr.family.substring(2) === family && net.isIP(addr.address)) {
-            result = {gateway: addr.address, interface: (iface ? iface : null)};
-            return true;
-          }
-        });
-      }
-    });
-
-    if (!result) {
-      throw new Error("Unable to determine default gateway");
-    }
-
-    return result;
+    return parse(stdout, family);
   });
+};
+
+const sync = family => {
+  const result = execa.sync("ip", args[family]);
+  return parse(result.stdout, family);
 };
 
 module.exports.v4 = () => get("v4");
 module.exports.v6 = () => get("v6");
+
+module.exports.v4.sync = () => sync("v4");
+module.exports.v6.sync = () => sync("v6");

--- a/linux.js
+++ b/linux.js
@@ -40,7 +40,7 @@ const parse = (stdout, family) => {
   return result;
 };
 
-const get = family => {
+const promise = family => {
   return execa.stdout("ip", args[family]).then(stdout => {
     return parse(stdout, family);
   });
@@ -51,8 +51,8 @@ const sync = family => {
   return parse(result.stdout, family);
 };
 
-module.exports.v4 = () => get("v4");
-module.exports.v6 = () => get("v6");
+module.exports.v4 = () => promise("v4");
+module.exports.v6 = () => promise("v6");
 
 module.exports.v4.sync = () => sync("v4");
 module.exports.v6.sync = () => sync("v6");

--- a/openbsd.js
+++ b/openbsd.js
@@ -30,7 +30,7 @@ const parse = stdout => {
   return result;
 };
 
-const get = family => {
+const promise = family => {
   return execa.stdout("netstat", args[family]).then(stdout => {
     return parse(stdout);
   });
@@ -41,8 +41,8 @@ const sync = family => {
   return parse(result.stdout);
 };
 
-module.exports.v4 = () => get("v4");
-module.exports.v6 = () => get("v6");
+module.exports.v4 = () => promise("v4");
+module.exports.v6 = () => promise("v6");
 
 module.exports.v4.sync = () => sync("v4");
 module.exports.v6.sync = () => sync("v6");

--- a/openbsd.js
+++ b/openbsd.js
@@ -9,28 +9,40 @@ const args = {
   v6: ["-rn", "-f", "inet6"],
 };
 
+const parse = stdout => {
+  let result;
+
+  (stdout || "").trim().split("\n").some(line => {
+    const results = line.split(/ +/) || [];
+    const target = results[0];
+    const gateway = results[1];
+    const iface = results[7];
+    if (dests.indexOf(target) !== -1 && gateway && net.isIP(gateway)) {
+      result = {gateway: gateway, interface: (iface ? iface : null)};
+      return true;
+    }
+  });
+
+  if (!result) {
+    throw new Error("Unable to determine default gateway");
+  }
+
+  return result;
+};
+
 const get = family => {
   return execa.stdout("netstat", args[family]).then(stdout => {
-    let result;
-
-    (stdout || "").trim().split("\n").some(line => {
-      const results = line.split(/ +/) || [];
-      const target = results[0];
-      const gateway = results[1];
-      const iface = results[7];
-      if (dests.indexOf(target) !== -1 && gateway && net.isIP(gateway)) {
-        result = {gateway: gateway, interface: (iface ? iface : null)};
-        return true;
-      }
-    });
-
-    if (!result) {
-      throw new Error("Unable to determine default gateway");
-    }
-
-    return result;
+    return parse(stdout);
   });
+};
+
+const sync = family => {
+  const result = execa.sync("netstat", args[family]);
+  return parse(result.stdout);
 };
 
 module.exports.v4 = () => get("v4");
 module.exports.v6 = () => get("v6");
+
+module.exports.v4.sync = () => sync("v4");
+module.exports.v6.sync = () => sync("v6");

--- a/package.json
+++ b/package.json
@@ -41,5 +41,8 @@
     "gateway",
     "routing",
     "route"
-  ]
+  ],
+  "devDependencies": {
+    "eslint": "^4.7.2"
+  }
 }

--- a/sunos.js
+++ b/sunos.js
@@ -30,7 +30,7 @@ const parse = stdout => {
   return result;
 };
 
-const get = family => {
+const promise = family => {
   return execa.stdout("netstat", args[family]).then(stdout => {
     return parse(stdout);
   });
@@ -41,8 +41,8 @@ const sync = family => {
   return parse(result.stdout);
 };
 
-module.exports.v4 = () => get("v4");
-module.exports.v6 = () => get("v6");
+module.exports.v4 = () => promise("v4");
+module.exports.v6 = () => promise("v6");
 
 module.exports.v4.sync = () => sync("v4");
 module.exports.v6.sync = () => sync("v6");

--- a/sunos.js
+++ b/sunos.js
@@ -9,28 +9,40 @@ const args = {
   v6: ["-rn", "-f", "inet6"],
 };
 
+const parse = stdout => {
+  let result;
+
+  (stdout || "").trim().split("\n").some(line => {
+    const results = line.split(/ +/) || [];
+    const target = results[0];
+    const gateway = results[1];
+    const iface = results[5];
+    if (dests.indexOf(target) !== -1 && gateway && net.isIP(gateway)) {
+      result = {gateway: gateway, interface: (iface ? iface : null)};
+      return true;
+    }
+  });
+
+  if (!result) {
+    throw new Error("Unable to determine default gateway");
+  }
+
+  return result;
+};
+
 const get = family => {
   return execa.stdout("netstat", args[family]).then(stdout => {
-    let result;
-
-    (stdout || "").trim().split("\n").some(line => {
-      const results = line.split(/ +/) || [];
-      const target = results[0];
-      const gateway = results[1];
-      const iface = results[5];
-      if (dests.indexOf(target) !== -1 && gateway && net.isIP(gateway)) {
-        result = {gateway: gateway, interface: (iface ? iface : null)};
-        return true;
-      }
-    });
-
-    if (!result) {
-      throw new Error("Unable to determine default gateway");
-    }
-
-    return result;
+    return parse(stdout);
   });
+};
+
+const sync = family => {
+  const result = execa.sync("netstat", args[family]);
+  return parse(result.stdout);
 };
 
 module.exports.v4 = () => get("v4");
 module.exports.v6 = () => get("v6");
+
+module.exports.v4.sync = () => sync("v4");
+module.exports.v6.sync = () => sync("v6");

--- a/test.js
+++ b/test.js
@@ -18,3 +18,13 @@ Promise.all([
   console.error(err.stack);
   process.exit(1);
 });
+
+if (defaultGateway.v4.sync) {
+  const result = defaultGateway.v4.sync();
+  assert(net.isIPv4(result.gateway));
+}
+
+if (defaultGateway.v6.sync) {
+  const result = defaultGateway.v6.sync();
+  assert(net.isIPv6(result.gateway));
+}

--- a/win32.js
+++ b/win32.js
@@ -6,9 +6,38 @@ const ipRegex = require("ip-regex");
 const gwArgs = "path Win32_NetworkAdapterConfiguration where IPEnabled=true get DefaultIPGateway,Index /format:table".split(" ");
 const ifArgs = "path Win32_NetworkAdapter get Index,NetConnectionID /format:table".split(" ");
 
-function wmic(family) {
+const parse = (gwTable, ifTable, family) => {
   let gateway, gwid, result;
 
+  (gwTable || "").trim().split("\n").splice(1).some(line => {
+    const results = line.trim().split(/} +/) || [];
+    const gw = results[0];
+    const id = results[1];
+    gateway = (ipRegex[family]().exec((gw || "").trim()) || [])[0];
+    if (gateway) {
+      gwid = id;
+      return true;
+    }
+  });
+
+  (ifTable || "").trim().split("\n").splice(1).some(line => {
+    const i = line.indexOf(" ");
+    const id = line.substr(0, i).trim();
+    const name = line.substr(i + 1).trim();
+    if (id === gwid) {
+      result = {gateway: gateway, interface: name ? name : null};
+      return true;
+    }
+  });
+
+  if (!result) {
+    throw new Error("Unable to determine default gateway");
+  }
+
+  return result;
+};
+
+const wmic = family => {
   return Promise.all([
     execa.stdout("wmic", gwArgs),
     execa.stdout("wmic", ifArgs),
@@ -16,34 +45,19 @@ function wmic(family) {
     const gwTable = results[0];
     const ifTable = results[1];
 
-    (gwTable || "").trim().split("\n").splice(1).some(line => {
-      const results = line.trim().split(/} +/) || [];
-      const gw = results[0];
-      const id = results[1];
-      gateway = (ipRegex[family]().exec((gw || "").trim()) || [])[0];
-      if (gateway) {
-        gwid = id;
-        return true;
-      }
-    });
-
-    (ifTable || "").trim().split("\n").splice(1).some(line => {
-      const i = line.indexOf(" ");
-      const id = line.substr(0, i).trim();
-      const name = line.substr(i + 1).trim();
-      if (id === gwid) {
-        result = {gateway: gateway, interface: name ? name : null};
-        return true;
-      }
-    });
-
-    if (!result) {
-      throw new Error("Unable to determine default gateway");
-    }
-
-    return result;
+    return parse(gwTable, ifTable, family);
   });
-}
+};
+
+const sync = family => {
+  const gwTable = execa.sync("wmic", gwArgs);
+  const ifTable = execa.sync("wmic", ifArgs);
+
+  return parse(gwTable, ifTable, family);
+};
 
 module.exports.v4 = () => wmic("v4");
 module.exports.v6 = () => wmic("v6");
+
+module.exports.v4.sync = () => sync("v4");
+module.exports.v6.sync = () => sync("v6");

--- a/win32.js
+++ b/win32.js
@@ -37,7 +37,7 @@ const parse = (gwTable, ifTable, family) => {
   return result;
 };
 
-const wmic = family => {
+const promise = family => {
   return Promise.all([
     execa.stdout("wmic", gwArgs),
     execa.stdout("wmic", ifArgs),
@@ -56,8 +56,8 @@ const sync = family => {
   return parse(gwTable, ifTable, family);
 };
 
-module.exports.v4 = () => wmic("v4");
-module.exports.v6 = () => wmic("v6");
+module.exports.v4 = () => promise("v4");
+module.exports.v6 = () => promise("v6");
 
 module.exports.v4.sync = () => sync("v4");
 module.exports.v6.sync = () => sync("v6");


### PR DESCRIPTION
This facilitates the re-addition of sync methods to `internal-ip`, citing [this issue there](https://github.com/sindresorhus/internal-ip/issues/13). All platforms for both families have been assigned sync methods using `execa.sync`. Tests were updated to also consider sync methods and run locally on OSX and Ubuntu with success.

This change is necessary in order for `internal-ip` and other consumers of `default-gateway` to implement synchronous methods. I followed the patterns established in the source but let me know if you'd like to see any semantic changes.